### PR TITLE
Manifest v3, Bandwidth Saving feature, Leagues API Fallback, Improved streamURL & replaceURL, Window Handling tweaks

### DIFF
--- a/LoLExtension/background.js
+++ b/LoLExtension/background.js
@@ -84,7 +84,7 @@ async function restoreMissingWindows() {
 
 // Function to reopen a window and update leagueWindowMap
 async function reopenLeagueWindow(leagueName, matchIDs) {
-    let matchLeagueURL = leagueList?.[leagueName] || FALLBACK_LEAGUE_URL[leagueName.trim()];
+    let matchLeagueURL = leagueList?.[leagueName] || FALLBACK_LEAGUE_URL[leagueName];
     if (!matchLeagueURL) {
         console.warn(`No valid URL found for league: ${leagueName}`);
         return null;
@@ -135,7 +135,7 @@ const fetchStreams = async (leagueName) => {
 
 	const events = data.data.schedule.events;
 	for (const event of events) {
-		if (event.league.name === leagueName) {
+		if (event.league.name.trim() === leagueName) {
 			try {
 				for (const stream of event.streams) {
 					streams.push(stream);
@@ -161,7 +161,7 @@ async function checkSchedule(data) {
     let leagueWindowMap = await getLeagueWindowMap(); // Get the latest leagueWindowMap
 
     for (const event of events) {
-        const leagueName = event.league.name;
+        const leagueName = event.league.name.trim();
         const matchID = event?.match?.id;
         const timeUntilMatch = new Date(event.startTime) - date;
 
@@ -184,7 +184,7 @@ async function checkSchedule(data) {
                 } else if (!leagueWindowMap[leagueName]) {
                     const { hasStreams } = await fetchStreams(leagueName);
                     if (hasStreams) {
-                        const matchLeagueURL = leagueList[leagueName] || FALLBACK_LEAGUE_URL[leagueName.trim()];
+                        const matchLeagueURL = leagueList[leagueName] || FALLBACK_LEAGUE_URL[leagueName];
                         if (!matchLeagueURL) {
                             console.warn(`No valid URL found for league: ${leagueName}`);
                             continue;
@@ -195,7 +195,7 @@ async function checkSchedule(data) {
 								matchIDs: matchID ? [matchID] : [], 
 								windowID: newWindow.id 
 							};
-							console.log(`Opened a New Window with ID: ${newWindow.id} for ${leagueName.trim()} - MatchID: ${matchID}`);
+							console.log(`Opened a New Window with ID: ${newWindow.id} for ${leagueName} - MatchID: ${matchID}`);
 						}
                     }
                 }
@@ -244,7 +244,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
     for (const leagueName in leagueWindowMap) {
         if (leagueWindowMap[leagueName].windowID === windowId) {
             delete leagueWindowMap[leagueName];
-            console.log(`Window with ID: ${windowId} closed by user for ${leagueName.trim()} at ${new Date().toLocaleString()}`);
+            console.log(`Window with ID: ${windowId} closed by user for ${leagueName} at ${new Date().toLocaleString()}`);
             await setLeagueWindowMap(leagueWindowMap); // Save updated map
             break;
         }
@@ -320,7 +320,7 @@ async function openWindowForLeague(matchURL, leagueName, matchID, timeNow) {
 
     const window = await createWindow(url, windowState);
     
-    console.log(`Opened window for ${leagueName.trim()}'s matches - ${timeNow}`);
+    console.log(`Opened window for ${leagueName}'s matches - ${timeNow}`);
     return window; // Return the window object
 }
 
@@ -335,7 +335,7 @@ async function checkURL() {
 
         // If undefined, check fallback lookup
         if (!matchLeagueURL) {
-            matchLeagueURL = FALLBACK_LEAGUE_URL[leagueName.trim()] || null;
+            matchLeagueURL = FALLBACK_LEAGUE_URL[leagueName] || null;
         }
 
         // If still null, log an error and skip this iteration

--- a/LoLExtension/background.js
+++ b/LoLExtension/background.js
@@ -1,22 +1,31 @@
 const API_URL = 'https://leaguewatcher.onrender.com/schedule';
 const LEAGUES_URL = 'https://leaguewatcher.onrender.com/leagues';
 const STREAMS_URL = 'https://leaguewatcher.onrender.com/streams';
+const FALLBACK_LEAGUE_URL = {"Americas Challengers":"https://lolesports.com/live/americas_challengers","Arabian League":"https://lolesports.com/live/arabian_league","CBLOL":"https://lolesports.com/live/cblol-brazil/cblolenglish","CBLOL Academy":"https://lolesports.com/live/cd","EMEA Masters":"https://lolesports.com/live/emea_masters/emeamasters","Esports Balkan League":"https://lolesports.com/live/esports_balkan_league","Hellenic Legends League":"https://lolesports.com/live/hellenic_legends_league/helleniclegends","Hitpoint Masters":"https://lolesports.com/live/hitpoint_masters/hitpointcz","LCK":"https://lolesports.com/live/lck/lck","LCK Challengers":"https://lolesports.com/live/lck_challengers_league/lckcl","LCL":"https://lolesports.com/live/lcl/lcl","LCO":"https://lolesports.com/live/lco/lco","LCP":"https://lolesports.com/live/lcp/lolpacificen","LCS":"https://lolesports.com/live/lcs/lcs","LEC":"https://lolesports.com/live/lec/lec","LJL":"https://lolesports.com/live/ljl-japan","LLA":"https://lolesports.com/live/lla/lla","LPL":"https://lolesports.com/live/lpl/lpl","LTA Cross-Conference":"https://lolesports.com/live/lta_cross","LTA North":"https://lolesports.com/live/lta_n/","LTA South":"https://lolesports.com/live/lta_s/ltaespanol","La Ligue Française":"https://lolesports.com/live/lfl/otplol_","Liga Portuguesa":"https://lolesports.com/live/liga_portuguesa/inygontv1","LoL Italian Tournament":"https://lolesports.com/live/lit/litofficial","MSI":"https://lolesports.com/live/msi/riotgames","NACL":"https://lolesports.com/live/nacl","NLC":"https://lolesports.com/live/nlc/nlclol","North Regional League":"https://lolesports.com/live/north_regional_league/lvpnorte","PCS":"https://lolesports.com/live/pcs/lolpacific","Prime League":"https://lolesports.com/live/primeleague","Rift Legends":"https://lolesports.com/live/rift_legends/nervarien","Road of Legends":"https://lolesports.com/live/roadoflegends/road_of_legends","South Regional League":"https://lolesports.com/live/south_regional_league/lvpsur","SuperLiga":"https://lolesports.com/live/superliga/lvpes","TCL":"https://lolesports.com/live/turkiye-sampiyonluk-ligi/riotgamesturkish","TFT Magic n' Mayhem":"https://lolesports.com/live/tft_esports/teamfighttactics","Ultraliga":"https://lolesports.com/live/ultraliga/polsatgames2","VCS":"https://lolesports.com/live/vcs/vcs","Worlds":"https://lolesports.com/live/worlds","TFT Esports":"https://lolesports.com/live/tft_esports/teamfighttactics"};
 
 const MATCH_WINDOW = 900 * 1000; // 15 minutes
-const SCHEDULE_POLL_INTERVAL = 180 * 1000; // 3 minutes
+const SCHEDULE_POLL_INTERVAL = 3; // 3 minutes
 
-const leagueWindowMap = new Map();
 const PROVIDER_TWITCH = 'twitch';
 const PROVIDER_YOUTUBE = 'youtube';
 
 let leagueList = null;
 
+async function getLeagueWindowMap() {
+    return await getFromLocalStorage('leagueWindowMap', {});
+}
+
+async function setLeagueWindowMap(map) {
+    await chrome.storage.local.set({ leagueWindowMap: map });
+}
+
+
 async function getFromLocalStorage(key, defaultValue) {
-	return new Promise((resolve) => {
-		chrome.storage.local.get(key, (result) => {
-			resolve(result[key] || defaultValue);
-		});
-	});
+    return new Promise((resolve) => {
+        chrome.storage.local.get([key], (result) => {
+            resolve(result[key] ?? defaultValue);
+        });
+    });
 }
 
 const isLeagueExcluded = async (leagueName) => {
@@ -33,9 +42,82 @@ const fetchJson = async (url) => {
 	}
 };
 
+async function restoreMissingWindows() {
+    let leagueWindowMap = await getLeagueWindowMap();
+    const updatedMap = {...leagueWindowMap};
+    let needsUpdate = false;
+
+    for (const [leagueName, leagueWindow] of Object.entries(leagueWindowMap)) {
+        const { windowID, matchIDs } = leagueWindow;
+
+        if (!windowID || typeof windowID !== "number") {
+            console.warn(`Invalid windowID for ${leagueName}, reopening...`);
+            const newWindow = await reopenLeagueWindow(leagueName, matchIDs);
+            if (newWindow) {
+                updatedMap[leagueName].windowID = newWindow.id;
+                needsUpdate = true;
+            }
+            continue;
+        }
+
+        try {
+            // Check if window exists
+            await chrome.windows.get(windowID);
+        } catch (error) {
+            console.warn(`Window for ${leagueName} is missing. Reopening...`);
+            const newWindow = await reopenLeagueWindow(leagueName, matchIDs);
+            if (newWindow) {
+				leagueWindowMap[leagueName] = { 
+					matchIDs: matchID ? [matchID] : [], 
+					windowID: newWindow.id 
+				};
+				console.log(`Opened new window ${newWindow.id} for ${leagueName}`);
+			}
+        }
+    }
+
+    // Only update storage if changes were made
+    if (needsUpdate) {
+        await setLeagueWindowMap(updatedMap);
+    }
+}
+
+// Function to reopen a window and update leagueWindowMap
+async function reopenLeagueWindow(leagueName, matchIDs) {
+    let matchLeagueURL = leagueList?.[leagueName] || FALLBACK_LEAGUE_URL[leagueName.trim()];
+    if (!matchLeagueURL) {
+        console.warn(`No valid URL found for league: ${leagueName}`);
+        return null;
+    }
+
+    const url = await streamURL(matchLeagueURL, leagueName);
+    const windowState = await getFromLocalStorage('windowState', 'normal');
+    
+    try {
+        const newWindow = await createWindow(url, windowState);
+        console.log(`Reopened window for ${leagueName} with new ID: ${newWindow.id}`);
+        
+        // Update map immediately
+        let leagueWindowMap = await getLeagueWindowMap();
+        leagueWindowMap[leagueName] = { matchIDs, windowID: newWindow.id };
+        await setLeagueWindowMap(leagueWindowMap);
+        
+        return newWindow;
+    } catch (error) {
+        console.error(`Failed to reopen window for ${leagueName}:`, error);
+        return null;
+    }
+}
+
 const fetchSchedule = async () => {
-	const data = await fetchJson(API_URL);
-	checkSchedule(data);
+    const data = await fetchJson(API_URL);
+    await checkSchedule(data);
+    
+    // avoid race condition
+    await new Promise(resolve => setTimeout(resolve, 500));
+    
+    // Now check for missing windows
+    await restoreMissingWindows();
 };
 
 const fetchLeagues = async () => {
@@ -67,114 +149,206 @@ const fetchStreams = async (leagueName) => {
 };
 
 async function checkSchedule(data) {
-	if (!data?.data?.schedule?.events) {
-		return;
-	}
+    if (!data?.data?.schedule?.events) {
+        return;
+    }
 
-	console.log('Checking schedule...');
-	const events = data.data.schedule.events;
-	const date = new Date();
-	const timeNow = new Date().toLocaleString();
-	leagueList = await fetchLeagues();
+    console.log('Checking schedule...');
+    const events = data.data.schedule.events;
+    const date = new Date();
+    const timeNow = new Date().toLocaleString();
+    leagueList = await fetchLeagues();
+    let leagueWindowMap = await getLeagueWindowMap(); // Get the latest leagueWindowMap
 
-	for (const event of events) {
-		const matchLeagueURL = leagueList[event.league.name];
-		const timeUntilMatch = new Date(event.startTime) - date;
-		const leagueName = event.league.name;
-		const matchID = event?.match?.id;
+    for (const event of events) {
+        const leagueName = event.league.name;
+        const matchID = event?.match?.id;
+        const timeUntilMatch = new Date(event.startTime) - date;
 
-		if (await isLeagueExcluded(leagueName)) {
-			continue;
-		}
+        if (await isLeagueExcluded(leagueName)) {
+            console.log(`League ${leagueName} is excluded. Skipping...`);
+            continue;
+        }
 
-		if (event?.state === 'unstarted' || (event?.state === 'inProgress' && event?.type === 'match')) {
-			if (
-				timeUntilMatch <= MATCH_WINDOW ||
-				(event?.state === 'inProgress' && leagueWindowMap.has(leagueName)) || // Accounts for matches starting earlier
-				(event?.state === 'inProgress' && !leagueWindowMap.has(leagueName))
-			) {
-				if (leagueWindowMap.has(leagueName) && !leagueWindowMap.get(leagueName).matchIDs.includes(matchID)) {
-					leagueWindowMap.get(leagueName).matchIDs.push(matchID);
-				} else if (!leagueWindowMap.has(leagueName)) {
-					const { hasStreams } = await fetchStreams(leagueName);
-					if (hasStreams) {
-						await openWindowForLeague(matchLeagueURL, leagueName, matchID, timeNow);
-					}
-				}
-			}
-		} else if (event?.state === 'completed') {
-			if (leagueWindowMap.has(leagueName) && leagueWindowMap.get(leagueName).matchIDs.includes(matchID)) {
-				leagueWindowMap.get(leagueName).matchIDs.splice(leagueWindowMap.get(leagueName).matchIDs.indexOf(matchID), 1);
-				console.log(`Match ${matchID} completed in ${leagueName} at ${timeNow}`);
-			}
+		//console.log(`Processing ${leagueName} - Match ID: ${matchID} - State: ${event.state}`);
 
-			if (leagueWindowMap.has(leagueName) && leagueWindowMap.get(leagueName).matchIDs.length === 0) {
-				console.log(`Closed window for matches in ${leagueName} at ${timeNow}`);
-				chrome.windows.remove(leagueWindowMap.get(leagueName).windowID);
-				leagueWindowMap.delete(leagueName);
-			}
-		}
-	}
-	await checkURL();
+        if (event?.state === 'unstarted' || (event?.state === 'inProgress' && (event?.type === 'match'))) {
+            if (
+                timeUntilMatch <= MATCH_WINDOW ||
+                (event?.state === 'inProgress' && leagueWindowMap[leagueName]) || 
+                (event?.state === 'inProgress' && !leagueWindowMap[leagueName])
+            ) {
+                if (leagueWindowMap[leagueName] && !leagueWindowMap[leagueName].matchIDs.includes(matchID)) {
+                    leagueWindowMap[leagueName].matchIDs.push(matchID);
+                    console.log(`Added match ${matchID} to existing window for ${leagueName}`);
+                } else if (!leagueWindowMap[leagueName]) {
+                    const { hasStreams } = await fetchStreams(leagueName);
+                    if (hasStreams) {
+                        const matchLeagueURL = leagueList[leagueName] || FALLBACK_LEAGUE_URL[leagueName.trim()];
+                        if (!matchLeagueURL) {
+                            console.warn(`No valid URL found for league: ${leagueName}`);
+                            continue;
+                        }
+                        const newWindow = await openWindowForLeague(matchLeagueURL, leagueName, matchID, timeNow);
+                        if (newWindow) {
+							leagueWindowMap[leagueName] = { 
+								matchIDs: matchID ? [matchID] : [], 
+								windowID: newWindow.id 
+							};
+							console.log(`Opened a New Window with ID: ${newWindow.id} for ${leagueName.trim()} - MatchID: ${matchID}`);
+						}
+                    }
+                }
+            }
+        } else if (event?.state === 'completed') {
+            if (leagueWindowMap[leagueName] && leagueWindowMap[leagueName].matchIDs.includes(matchID)) {
+                leagueWindowMap[leagueName].matchIDs = leagueWindowMap[leagueName].matchIDs.filter(id => id !== matchID);
+                console.log(`Match ${matchID} completed in ${leagueName} at ${timeNow}`);
+            }
+
+            if (leagueWindowMap[leagueName] && leagueWindowMap[leagueName].matchIDs.length === 0) {
+                console.log(`Closing window for ${leagueName} at ${timeNow}`);
+                try {
+                    await chrome.windows.remove(leagueWindowMap[leagueName].windowID);
+                    console.log(`Successfully closed window ${leagueWindowMap[leagueName].windowID}`);
+                } catch (error) {
+                    console.warn(`Failed to close window ${leagueWindowMap[leagueName].windowID}, it may have been already closed.`);
+                }
+                delete leagueWindowMap[leagueName];
+            }
+        }
+    }
+
+    await setLeagueWindowMap(leagueWindowMap); // Store the updated map
+    await checkURL();
 }
 
-chrome.windows.onRemoved.addListener((windowId) => {
-	for (const [leagueName, leagueWindow] of leagueWindowMap.entries()) {
-		if (leagueWindow.windowID === windowId) {
-			leagueWindowMap.delete(leagueName);
-			console.log(`Window ${windowId} closed by user for ${leagueName} at ${new Date().toLocaleString()}`);
-			break;
-		}
-	}
+// Player Option Listner
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.action === "togglePlayerRemoval") {
+        console.log(`Player Removal ${message.enabled ? "ENABLED" : "DISABLED"}`);
+        chrome.storage.local.set({ removePlayerEnabled: message.enabled });
+
+        // Forward the message to content.js
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            if (tabs.length > 0) {
+                chrome.tabs.sendMessage(tabs[0].id, { action: "togglePlayerRemoval", enabled: message.enabled });
+            }
+        });
+    }
+});
+
+chrome.windows.onRemoved.addListener(async (windowId) => {
+    let leagueWindowMap = await getLeagueWindowMap(); // Get the latest leagueWindowMap
+
+    for (const leagueName in leagueWindowMap) {
+        if (leagueWindowMap[leagueName].windowID === windowId) {
+            delete leagueWindowMap[leagueName];
+            console.log(`Window with ID: ${windowId} closed by user for ${leagueName.trim()} at ${new Date().toLocaleString()}`);
+            await setLeagueWindowMap(leagueWindowMap); // Save updated map
+            break;
+        }
+    }
 });
 
 async function createWindow(url, state) {
-	return new Promise((resolve) => {
-		chrome.windows.create({ url, state }, resolve);
-	});
+    try {
+        return await new Promise((resolve, reject) => {
+            chrome.windows.create({ url, state }, (window) => {
+                if (chrome.runtime.lastError || !window) {
+                    reject(`Failed to create window: ${chrome.runtime.lastError?.message}`);
+                } else {
+                    resolve(window);
+                }
+            });
+        });
+    } catch (error) {
+        console.error("Error creating window:", error);
+    }
 }
 
 function replaceURL(url, parameter) {
-	let urlObj = new URL(url);
-	let pathnames = urlObj.pathname.split('/').filter(Boolean);
-	pathnames[pathnames.length - 1] = parameter;
-	urlObj.pathname = pathnames.join('/');
-	return urlObj.toString();
+    let urlObj = new URL(url);
+    let pathnames = urlObj.pathname.split('/').filter(Boolean);
+
+    // Find the index of '/live/' to determine relevant paths
+    let liveIndex = pathnames.indexOf("live");
+
+    if (liveIndex !== -1) {
+        let afterLive = pathnames.slice(liveIndex + 1); // Paths after "live"
+
+        if (afterLive.length === 1) {
+            // If only one path after "/live/", append the parameter
+            pathnames.push(parameter);
+        } else {
+            // Otherwise, replace the last segment
+            pathnames[pathnames.length - 1] = parameter;
+        }
+
+        urlObj.pathname = "/" + pathnames.join('/');
+    }
+
+    return urlObj.toString();
 }
 
 const streamURL = async (matchURL, leagueName) => {
-	const provider = await getFromLocalStorage('provider', PROVIDER_TWITCH);
-	const { streams } = await fetchStreams(leagueName);
-	const youtubeStream = streams.find((stream) => stream.provider === PROVIDER_YOUTUBE);
+    const provider = await getFromLocalStorage('provider', PROVIDER_TWITCH);
+    const { streams } = await fetchStreams(leagueName);
+    
+    const youtubeStream = streams.find((stream) => stream.provider === PROVIDER_YOUTUBE);
+    const twitchStream = streams.find((stream) => stream.provider === PROVIDER_TWITCH);
+    
+    let streamId;
+    
+    if (provider === PROVIDER_YOUTUBE) {
+        streamId = youtubeStream?.parameter || twitchStream?.parameter; // Prefer YouTube, fallback to Twitch
+    } else {
+        streamId = twitchStream?.parameter || youtubeStream?.parameter; // Prefer Twitch, fallback to YouTube
+    }
 
-	let url;
-	if (provider === PROVIDER_YOUTUBE && youtubeStream) {
-		let streamId = youtubeStream.parameter;
-		url = replaceURL(matchURL, streamId);
-	} else {
-		url = matchURL;
-	}
+    if (!streamId) {
+        console.warn(`No valid stream found for ${leagueName}, using given matchURL.`);
+        return matchURL;
+    }
 
-	return url;
+    return replaceURL(matchURL, streamId);
 };
 
 async function openWindowForLeague(matchURL, leagueName, matchID, timeNow) {
-	const windowState = await getFromLocalStorage('windowState', 'normal');
-	const url = await streamURL(matchURL, leagueName);
+    const windowState = await getFromLocalStorage('windowState', 'normal');
+    const url = await streamURL(matchURL, leagueName);
 
-	const window = await createWindow(url, windowState);
-	leagueWindowMap.set(leagueName, { matchIDs: [matchID], windowID: window.id });
-	console.log(`Opened window for matches in ${leagueName} at ${timeNow}`);
+    const window = await createWindow(url, windowState);
+    
+    console.log(`Opened window for ${leagueName.trim()}'s matches - ${timeNow}`);
+    return window; // Return the window object
 }
 
 async function checkURL() {
-	for (const [leagueName, leagueWindow] of leagueWindowMap.entries()) {
-		const { windowID } = leagueWindow;
-		const matchLeagueURL = leagueList[leagueName];
-		const url = await streamURL(matchLeagueURL, leagueName);
+    let leagueWindowMap = await getLeagueWindowMap(); // Get the latest leagueWindowMap
 
-		await updateTabURL(windowID, url);
-	}
+    for (const [leagueName, leagueWindow] of Object.entries(leagueWindowMap)) {
+        const { windowID } = leagueWindow;
+
+        // First, try to get the URL from leagueList
+        let matchLeagueURL = leagueList[leagueName];
+
+        // If undefined, check fallback lookup
+        if (!matchLeagueURL) {
+            matchLeagueURL = FALLBACK_LEAGUE_URL[leagueName.trim()] || null;
+        }
+
+        // If still null, log an error and skip this iteration
+        if (!matchLeagueURL) {
+            console.warn(`No valid URL found for league: ${leagueName}`);
+            continue;
+        }
+
+        // Get the correct stream URL
+        const url = await streamURL(matchLeagueURL, leagueName);
+
+        await updateTabURL(windowID, url);
+    }
 }
 
 async function getTab(windowId) {
@@ -196,6 +370,20 @@ async function updateTabURL(windowId, matchURL) {
 	return tab;
 }
 
-chrome.runtime.onInstalled.addListener(fetchSchedule);
+chrome.runtime.onInstalled.addListener(async () => {
+    try {
+        await fetchSchedule();
+    } catch (error) {
+        console.error("Failed to fetch schedule on install:", error);
+    }
+});
 
-setInterval(fetchSchedule, SCHEDULE_POLL_INTERVAL);
+chrome.alarms.clearAll(() => {
+    chrome.alarms.create("fetchSchedule", { periodInMinutes: SCHEDULE_POLL_INTERVAL });
+});
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+    if (alarm.name === "fetchSchedule") {
+        await fetchSchedule();
+    }
+});

--- a/LoLExtension/content.js
+++ b/LoLExtension/content.js
@@ -1,0 +1,77 @@
+console.log("League Watcher Content Script Loaded!");
+
+chrome.runtime.onMessage.addListener((message) => {
+    if (message.action === "togglePlayerRemoval") {
+        if (message.enabled) {
+            console.log("Player Removal ENABLED.");
+            enablePlayerRemoval();
+        } else {
+            console.log("Player Removal DISABLED.");
+            disablePlayerRemoval();
+        }
+    }
+});
+
+// Selectors
+const HOMEPAGE_PLAYER = "#video-player-placeholder";
+const LIVE_PLAYER = "#video-player";
+const REWARDS_BUTTON = '.status-summary[role="button"]';
+
+function removeElement(selector, logMessage) {
+    const element = document.querySelector(selector);
+    if (element) {
+        element.remove();
+        console.log(logMessage);
+    }
+}
+
+function observeAndRemove(selector, logMessage) {
+    const observer = new MutationObserver(() => {
+        if (document.querySelector(selector)) {
+            removeElement(selector, logMessage);
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+    removeElement(selector, logMessage); // Remove immediately if present
+}
+
+function waitForElement(selector, callback) {
+    if (document.querySelector(selector)){
+        callback();
+    }
+    const observer = new MutationObserver((mutations, obs) => {
+        if (document.querySelector(selector)) {
+            callback();
+            obs.disconnect(); // Stop observing once found
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+}
+
+// Enable player removal when toggled on
+function enablePlayerRemoval() {
+    if (window.location.href.startsWith("https://lolesports.com/live/")) {
+        console.log("On live match page, waiting for Rewards button...");
+        waitForElement(REWARDS_BUTTON, () => {
+            console.log("Rewards button detected, removing live video player...");
+            removeElement(LIVE_PLAYER, "Removed live video player");
+        });
+    } else {
+        console.log("On homepage, removing homepage video player...");
+        observeAndRemove(HOMEPAGE_PLAYER, "Removed homepage video player");
+    }
+}
+
+// Disable player removal when toggled off (nothing to restore, just stop observers)
+function disablePlayerRemoval() {
+    console.log("Player removal disabled, but elements won't be restored.");
+}
+
+// Apply settings on load
+chrome.storage.local.get("removePlayerEnabled", (data) => {
+    if (data.removePlayerEnabled) {
+        enablePlayerRemoval();
+    }
+});

--- a/LoLExtension/manifest.json
+++ b/LoLExtension/manifest.json
@@ -1,20 +1,29 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "LoL Stream Opener",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Automatically opens games on lolesports.com in a new window.",
   "background": {
-    "scripts": ["background.js"],
-    "persistent": true
+    "service_worker": "background.js"
   },
   "permissions": [
     "tabs",
     "storage",
     "activeTab",
+    "alarms"
+  ],
+  "host_permissions": [
     "https://leaguewatcher.onrender.com/*",
     "https://lolesports.com/*"
   ],
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://lolesports.com/live/*", "https://lolesports.com/en-US/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
 }

--- a/LoLExtension/popup.html
+++ b/LoLExtension/popup.html
@@ -145,6 +145,16 @@
         </label>
         <div id="excludeLeagues"></div>
     </div>
+    <div class="container">
+        <label class="label">
+            <h2>Player</h2>
+        </label>
+        <div class="button-container">
+            <label class="label">Remove Player</label>
+            <button id="removePlayerButton" class="button off">OFF</button>
+        </div>
+        
+    </div>
     <script src="popup.js"></script>
 </body>
 

--- a/LoLExtension/popup.js
+++ b/LoLExtension/popup.js
@@ -21,6 +21,33 @@ document.addEventListener('DOMContentLoaded', () => {
 		chrome.storage.local.set({ windowState: selectedState });
 	});
 
+	const removePlayerButton = document.getElementById('removePlayerButton');
+
+	// Load the Remove Player toggle state from storage
+	chrome.storage.local.get('removePlayerEnabled', (result) => {
+	    const isEnabled = result.removePlayerEnabled || false;
+	    updateRemovePlayerButton(isEnabled);
+	});
+
+	// Add event listener for the Remove Player button
+	removePlayerButton.addEventListener('click', () => {
+	    chrome.storage.local.get('removePlayerEnabled', (result) => {
+	        const isEnabled = !(result.removePlayerEnabled || false); // Toggle state
+	        chrome.storage.local.set({ removePlayerEnabled: isEnabled });
+	        updateRemovePlayerButton(isEnabled);
+
+	        // Send a unified message
+	        chrome.runtime.sendMessage({ action: "togglePlayerRemoval", enabled: isEnabled });
+	    });
+	});
+
+	function updateRemovePlayerButton(isEnabled) {
+	    removePlayerButton.textContent = isEnabled ? "ON" : "OFF";
+	    removePlayerButton.classList.toggle("on", isEnabled);
+	    removePlayerButton.classList.toggle("off", !isEnabled);
+	}
+
+
 	const leagueNames = [
 	    "LTA North",
 	    "LTA South",
@@ -62,7 +89,8 @@ document.addEventListener('DOMContentLoaded', () => {
 	    "CBLOL",
 	    "LCL",
 	    "First Stand",
-	    "LTA Cross-Conference"
+	    "LTA Cross-Conference",
+		"TFT Esports"
 	];
 
 	chrome.storage.local.get('excludedLeagues', (result) => {


### PR DESCRIPTION

# Changelog

- **Updated manifest to v3**

- **Added `content.js` script for bandwidth saving**
  - is toggleable and off by default.

- **Added a fallback lookup object for undefined `matchLeagueURL`**

- **Improved streamURL & replaceURL functions to rely more on "streams" API endpoint's data**

- **some minor Window Handling tweaks**